### PR TITLE
fix: Fix repo URLs in version information dialog (#1464)

### DIFF
--- a/src/components/settings/VersionInformationDialog.vue
+++ b/src/components/settings/VersionInformationDialog.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script lang="ts">
-import type { ArtifactVersion, HashVersion, OSPackage } from '@/store/version/types'
+import type { UpdatePackage } from '@/store/version/types'
 import { Component, Vue, Prop, VModel } from 'vue-property-decorator'
 
 @Component({})
@@ -100,7 +100,7 @@ export default class VersionInformationDialog extends Vue {
     open?: boolean
 
   @Prop({ type: Object })
-  readonly component!: HashVersion | ArtifactVersion | OSPackage
+  readonly component!: UpdatePackage
 
   // For HashVersions or ArtifacVersions, show the commit history.
   // For type system, show the packages available to update.
@@ -112,7 +112,7 @@ export default class VersionInformationDialog extends Vue {
 
   get baseUrl () {
     if ('owner' in this.component) {
-      return `https://github.com/${this.component.owner}/${this.component.key}`
+      return `https://github.com/${this.component.owner}/${this.component.repo_name || this.component.key}`
     }
     return ''
   }

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -180,7 +180,7 @@ import VersionStatus from './VersionStatus.vue'
 import VersionCommitHistoryDialog from './VersionInformationDialog.vue'
 import StateMixin from '@/mixins/state'
 import { SocketActions } from '@/api/socketActions'
-import type { ArtifactVersion, HashVersion, OSPackage } from '@/store/version/types'
+import type { VersionedUpdatePackage, UpdatePackage } from '@/store/version/types'
 
 @Component({
   components: {
@@ -219,7 +219,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
     })
   }
 
-  packageTitle (component: HashVersion | OSPackage | ArtifactVersion) {
+  packageTitle (component: UpdatePackage) {
     if (component.key === 'system') {
       return this.$t('app.version.label.os_packages')
     }
@@ -231,7 +231,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
     return this.$store.getters['version/hasUpdate'](component)
   }
 
-  inError (component: HashVersion | OSPackage | ArtifactVersion) {
+  inError (component: UpdatePackage) {
     const dirty = ('is_dirty' in component) ? component.is_dirty : false
     const valid = ('is_valid' in component) ? component.is_valid : true
     return (dirty || !valid)
@@ -262,7 +262,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
   }
 
   // Will attempt to recover a component based on its type and current status.
-  handleRecoverComponent (component: HashVersion | OSPackage | ArtifactVersion) {
+  handleRecoverComponent (component: UpdatePackage) {
     this.$store.dispatch('version/onUpdateStatus', { busy: true })
     const dirty = ('is_dirty' in component) ? component.is_dirty : false
     const valid = ('is_valid' in component) ? component.is_valid : true
@@ -282,17 +282,17 @@ export default class VersionSettings extends Mixins(StateMixin) {
     }
   }
 
-  getBaseUrl (component: HashVersion | ArtifactVersion) {
+  getBaseUrl (component: VersionedUpdatePackage) {
     if ('remote_url' in component && component.remote_url) {
       return component.remote_url
     }
     if ('owner' in component) {
-      return `https://github.com/${component.owner}/${component.key}`
+      return `https://github.com/${component.owner}/${component.repo_name || component.key}`
     }
     return ''
   }
 
-  handleInformationDialog (component: HashVersion | OSPackage | ArtifactVersion) {
+  handleInformationDialog (component: UpdatePackage) {
     if (
       'commits_behind' in component ||
       'package_list' in component

--- a/src/store/version/getters.ts
+++ b/src/store/version/getters.ts
@@ -47,7 +47,9 @@ export const getters: GetterTree<VersionState, RootState> = {
       }
     } else if ('package_count' in componentVersionInfo) {
       return componentVersionInfo.package_count > 0
-    } else {
+    }
+
+    if ('current_hash' in componentVersionInfo && 'remote_hash' in componentVersionInfo) {
       return componentVersionInfo.current_hash !== componentVersionInfo.remote_hash
     }
 

--- a/src/store/version/types.ts
+++ b/src/store/version/types.ts
@@ -8,39 +8,82 @@ export interface VersionState {
   fluidd: FluiddVersion;
 }
 
-export interface VersionComponents {
-  [key: string]: HashVersion | ArtifactVersion | OSPackage;
-}
+export type VersionComponents = Record<string, UpdatePackage>;
 
-/** For klipper / moonraker */
-export interface HashVersion {
+/**
+ * Base interface for all versioned packages
+ */
+export interface VersionedPackage {
   key: string;
-  configured_type?: string;
-  detected_type?: string;
-  channel?: string;
-  pristine?: boolean;
+  channel?: 'stable' | 'beta' | 'dev';
+  channel_invalid?: boolean;
+  detected_type?: 'git_repo'; // As far as I can tell, this is the only possible value that Moonraker can return for this field.
+  debug_enabled: boolean;
+  is_valid: boolean;
+  name: string;
+  repo_name?: string;
   owner: string;
-  branch: string;
-  remote_alias: string;
   version: string;
   remote_version: string;
   rollback_version?: string;
-  full_version_string: string;
-  current_hash: string;
-  remote_hash: string;
-  is_valid: boolean;
-  corrupt?: boolean;
-  is_dirty: boolean;
-  detached: boolean;
-  debug_enabled: boolean;
-  commits_behind: CommitItem[];
-  git_messages: string[];
   info_tags?: string[];
-  recovery_url?: string;
-  remote_url?: string;
   warnings?: string[];
   anomalies?: string[];
 }
+
+/**
+ * Updates are deployed directly via git.
+ * Typical usage scenarios are to manage extensions installed a service.
+ * eg. KlipperScreen, repos containing configs, etc.
+ *
+ * See: https://moonraker.readthedocs.io/en/latest/configuration/#git-type-application-configuration
+ */
+export interface GitUpdatePackage extends VersionedPackage {
+  configured_type?: 'git_repo';
+  pristine?: boolean;
+  branch: string;
+  remote_alias: string;
+  full_version_string: string;
+  current_hash: string;
+  remote_hash: string;
+  corrupt?: boolean;
+  is_dirty: boolean;
+  detached: boolean;
+  commits_behind: CommitItem[];
+  commits_behind_count: number;
+  git_messages: string[];
+  recovery_url?: string;
+  remote_url?: string;
+}
+
+/**
+ * `web` packages are simple packages that can be updated by downloading a zip of a github release.
+ * They are not capable of performing any additional actions.
+ * e.g. updating dependencies, building from source, managing services, etc
+ *
+ * See: https://moonraker.readthedocs.io/en/latest/configuration/#web-type-front-end-configuration
+ */
+export interface WebUpdatePackage extends VersionedPackage {
+  configured_type?: 'web';
+  /** Note: Can be an empty string */
+  last_error?: string;
+}
+
+/**
+ * `zip` packages are a combination of the `web` and `git_repo` types.
+ * Compared to `web` packages, `zip` packages have can perform actions such as
+ * updating of dependencies, building from source, managing services, etc.
+ *
+ * See: https://moonraker.readthedocs.io/en/latest/configuration/#zip-application-configuration
+ */
+export interface ZipUpdatePackage extends VersionedPackage {
+  configured_type?: 'zip';
+  /** Note: Can be an empty string */
+  last_error?: string;
+}
+
+export type VersionedUpdatePackage = GitUpdatePackage | WebUpdatePackage | ZipUpdatePackage;
+export type UpdatePackage = VersionedUpdatePackage | OSPackage;
 
 export interface CommitItem {
   author: string;
@@ -56,22 +99,6 @@ export interface OSPackage {
   key: string;
   package_count: number;
   package_list: string[];
-}
-
-/** For clients */
-export interface ArtifactVersion {
-  key: string;
-  channel?: string;
-  configured_type?: string;
-  name: string;
-  owner: string;
-  version: string;
-  remote_version: string;
-  rollback_version?: string;
-  info_tags?: string[];
-  is_valid: boolean;
-  warnings?: string[];
-  anomalies?: string[];
 }
 
 export interface FluiddVersion {


### PR DESCRIPTION
Use `owner/repo_name` instead of `owner/key` for the repo URLs in the version information dialog.

Updated related types.

<!---
Thank you for contributing to Fluidd.  Before creating your pull request please review the [contributing guidelines](https://github.com/fluidd-core/fluidd/blob/master/CONTRIBUTING.md).

Be sure that every commit in it contains a footer with your real name and a reachable email address.

Alternatively, please add your real name and a reachable email address in the footer of this Pull Request.

Your signature acknowledges that you accept the [developer certificate of origin](https://github.com/fluidd-core/fluidd/blob/master/developer-certificate-of-origin).
--->
